### PR TITLE
Add mutect2

### DIFF
--- a/tools.yaml
+++ b/tools.yaml
@@ -227,3 +227,7 @@ tools:
   - name: bcftools_concat
     owner: iuc
     tool_panel_section_label: Variation
+
+  - name: gatk4_mutect2
+    owner: iuc
+    tool_panel_section_label: Variation


### PR DESCRIPTION
The galaxy server is currently using a deprecated version of mutect2 at https://toolshed.g2.bx.psu.edu/repository?repository_id=fbc9ca61b724ca1e
Can we remove this one and add the mutect2 tool maintained by the IUC?